### PR TITLE
fix issues that Libinfo call to mDNSResponder on main thread, this may freeze the app

### DIFF
--- a/MQTTKit/MQTTKit.m
+++ b/MQTTKit/MQTTKit.m
@@ -238,10 +238,9 @@ static void on_unsubscribe(struct mosquitto *mosq, void *obj, int message_id)
     // FIXME: check for errors
     mosquitto_username_pw_set(mosq, cstrUsername, cstrPassword);
     mosquitto_reconnect_delay_set(mosq, self.reconnectDelay, self.reconnectDelayMax, self.reconnectExponentialBackoff);
-
-    mosquitto_connect(mosq, cstrHost, self.port, self.keepAlive);
     
     dispatch_async(self.queue, ^{
+        mosquitto_connect(mosq, cstrHost, self.port, self.keepAlive);
         LogDebug(@"start mosquitto loop on %@", self.queue);
         mosquitto_loop_forever(mosq, -1, 1);
         LogDebug(@"end mosquitto loop on %@", self.queue);


### PR DESCRIPTION
Warning: Libinfo call to mDNSResponder on main thread

If mqtt_connect run in main queue, will get the warning above.  If the network is bad, it will block the main thread, and then freeze the app.
