### PR TITLE
Serious bug in MQTTKit.m

### DIFF
--- a/MQTTKit/MQTTKit.m
+++ b/MQTTKit/MQTTKit.m
@@ -193,6 +193,7 @@ static void on_unsubscribe(struct mosquitto *mosq, void *obj, int message_id)
         self.subscriptionHandlers = [[NSMutableDictionary alloc] init];
         self.unsubscriptionHandlers = [[NSMutableDictionary alloc] init];
         self.publishHandlers = [[NSMutableDictionary alloc] init];
+        self.cleanSession = cleanSession;
 
         const char* cstrClientId = [self.clientID cStringUsingEncoding:NSUTF8StringEncoding];
 


### PR DESCRIPTION
Serious bug here, which tied up my server for a week.  initWithClientId takes BOOL cleanSession as parameter, which is almost always set to YES.  However, when it sends it to mosquito_new(), it sends the class property, self.cleanSession, which is not initialized, thus is always NO.  Using this code sets durable clients in the file, and causes the transmit queue to clog up waiting for those clients to sign in again and get their messages.
